### PR TITLE
[KIECLOUD-242] references to content_sets.yml missing in 6.4 image.yaml files

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -58,6 +58,8 @@ modules:
                   ref: master
       install:
           - name: jboss-kieserver-6
+packages:
+      content_sets_file: content_sets.yml
 osbs:
       configuration:
           container_file: container.yaml


### PR DESCRIPTION
[KIECLOUD-242] references to content_sets.yml missing in 6.4 image.yaml files
https://issues.jboss.org/browse/KIECLOUD-242

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject` or `[RHDM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
