### PR TITLE
[KIECLOUD-279] Move 6.4 kieserver modules into 6.4 repositories

### DIFF
--- a/branch-overrides.yaml
+++ b/branch-overrides.yaml
@@ -23,7 +23,3 @@ modules:
             git:
                   url: https://github.com/jboss-container-images/jboss-kieserver-6-openshift-image.git
                   ref: 6.4.x
-          - name: jboss-kie-modules
-            git:
-                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
-                  ref: master

--- a/image.yaml
+++ b/image.yaml
@@ -52,12 +52,13 @@ modules:
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-6-image.git
                   ref: eap64-dev
-          - name: jboss-kie-modules
+          - name: jboss-kieserver-6-openshift-image
             git:
-                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
-                  ref: master
+                  url: https://github.com/jboss-container-images/jboss-kieserver-6-openshift-image.git
+                  ref: 6.4.x
       install:
-          - name: jboss-kieserver-6
+          - name: jboss-kieserver
+            version: "6.4"
 packages:
       content_sets_file: content_sets.yml
 osbs:

--- a/tag-overrides.yaml
+++ b/tag-overrides.yaml
@@ -23,8 +23,4 @@ modules:
           - name: jboss-kieserver-6-openshift-image
             git:
                   url: https://github.com/jboss-container-images/jboss-kieserver-6-openshift-image.git
-                  ref: rhdm-6.4.12.GA
-          - name: jboss-kie-modules
-            git:
-                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
-                  ref: rhdm-6.4.12.GA
+                  ref: 6.4.12.GA

--- a/tests/features/decisionserver_6_3.feature
+++ b/tests/features/decisionserver_6_3.feature
@@ -1,0 +1,56 @@
+@jboss-decisionserver-6/decisionserver63-openshift
+Feature: OpenShift Decision Server 6.3 basic tests
+  
+  Scenario: Check for add-user failures
+    When container is ready
+    Then container log should contain Running jboss-decisionserver-6/decisionserver63-openshift image
+     And available container log should not contain AddUserFailedException
+
+  Scenario: Check for product and version  environment variables
+    When container is ready
+    Then run sh -c 'echo $JBOSS_PRODUCT' in container and check its output for decisionserver
+     And run sh -c 'echo $JBOSS_DECISIONSERVER_VERSION' in container and check its output for 6.3
+
+  Scenario: Checks if the kie-server webapp is deployed.
+    When container is ready
+    Then container log should contain JBAS015859: Deployed "kie-server.war"
+
+  Scenario: Test REST API is secure
+    When container is ready
+    Then check that page is served
+         | property | value |
+         | port     | 8080  |
+         | path     | /kie-server/services/rest/server |
+         | expected_status_code | 401 |
+
+   Scenario: Test REST API is available and valid
+     When container is ready
+     Then check that page is served
+         | property | value |
+         | port     | 8080  |
+         | path     | /kie-server/services/rest/server |
+         | username | kieserver |
+         | password | kieserver1! |
+         | expected_phrase | SUCCESS |
+
+   Scenario: Test CLOUD-458
+     Given s2i build https://github.com/jboss-openshift/application-templates using ose-v1.0.0 
+     Then s2i build log should not contain cp: cannot stat '/tmp/src/*': No such file or directory
+     Then s2i build log should not contain ls: cannot access /opt/eap/standalone/deployments/*.jar: No such file or directory
+     Then s2i build log should not contain chmod: cannot access '/home/jboss/.m2/repository': No such file or directory
+
+  Scenario: check ownership when started as alternative UID
+    When container is started as uid 26458
+    Then container log should contain Running
+     And run id -u in container and check its output contains 26458
+     And all files under /opt/eap are writeable by current user
+     And all files under /deployments are writeable by current user
+
+  Scenario: Checks that CLOUD-950/CLOUD-951 upgrade to 6.3.4 was successful
+    When container is ready
+    Then file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/web.xml should contain org.openshift.kieserver
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/security-filter-rules.properties should exist
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/lib/kie-api-6.4.0.Final-redhat-3.jar should not exist
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/lib/kie-api-6.4.0.Final-redhat-13.jar should exist
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/lib/openshift-kieserver-common-1.0.8.Final-redhat-1.jar should not exist
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/lib/openshift-kieserver-common-1.1.0.Final-redhat-1.jar should exist

--- a/tests/features/decisionserver_6_4.feature
+++ b/tests/features/decisionserver_6_4.feature
@@ -1,0 +1,55 @@
+@jboss-decisionserver-6/decisionserver64-openshift
+Feature: OpenShift Decision Server 6.4 basic tests
+  
+  Scenario: Check for add-user failures
+    When container is ready
+    Then container log should contain Running jboss-decisionserver-6/decisionserver64-openshift image
+     And available container log should not contain AddUserFailedException
+
+  Scenario: Check for product and version  environment variables
+    When container is ready
+    Then run sh -c 'echo $JBOSS_PRODUCT' in container and check its output for decisionserver
+     And run sh -c 'echo $JBOSS_DECISIONSERVER_VERSION' in container and check its output for 6.4
+
+  Scenario: Checks if the kie-server webapp is deployed.
+    When container is ready
+    Then container log should contain Deployed "kie-server.war"
+
+  Scenario: Test REST API is secure
+    When container is ready
+    Then check that page is served
+         | property | value |
+         | port     | 8080  |
+         | path     | /kie-server/services/rest/server |
+         | expected_status_code | 401 |
+
+   Scenario: Test REST API is available and valid
+     When container is ready
+     Then check that page is served
+         | property | value |
+         | port     | 8080  |
+         | path     | /kie-server/services/rest/server |
+         | username | kieserver |
+         | password | kieserver1! |
+         | expected_phrase | SUCCESS |
+
+   Scenario: Test CLOUD-458
+     Given s2i build https://github.com/jboss-openshift/application-templates using ose-v1.0.0 
+     Then s2i build log should not contain cp: cannot stat '/tmp/src/*': No such file or directory
+     Then s2i build log should not contain ls: cannot access /opt/eap/standalone/deployments/*.jar: No such file or directory
+     Then s2i build log should not contain chmod: cannot access '/home/jboss/.m2/repository': No such file or directory
+
+  Scenario: check ownership when started as alternative UID
+    When container is started as uid 26458
+    Then container log should contain Running
+     And run id -u in container and check its output contains 26458
+     And all files under /opt/eap are writeable by current user
+     And all files under /deployments are writeable by current user
+
+  Scenario: Checks that CLOUD-1476 patch upgrade was successful
+    When container is ready
+    Then file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/web.xml should contain org.openshift.kieserver
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/security-filter-rules.properties should exist
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/lib/kie-api-6.5.0.Final-redhat-2.jar should not exist
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/lib/kie-api-6.5.0.Final-redhat-25.jar should exist
+    And file /opt/eap/standalone/deployments/kie-server.war/WEB-INF/lib/openshift-kieserver-common-1.2.2.Final-redhat-1.jar should exist

--- a/tests/features/decisionserver_s2i.feature
+++ b/tests/features/decisionserver_s2i.feature
@@ -1,0 +1,50 @@
+@jboss-decisionserver-6
+Feature: Openshift Decision Server s2i tests
+
+  Scenario: deploys the hellorules example, then checks if it's deployed.
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from decisionserver/hellorules using 1.2
+       | variable                       | value                                                                               |
+       | KIE_CONTAINER_DEPLOYMENT       | HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.2.0.Final |
+       | KIE_CONTAINER_REDIRECT_ENABLED | false |
+    Then container log should contain Container HelloRulesContainer
+
+  # Always force IPv4 (CLOUD-188)
+  # Support user-supplied arguments (CLOUD-412)
+  # Allow the user to clear down the maven repository after running s2i (CLOUD-413)
+  Scenario: Test to ensure that maven is run with -Djava.net.preferIPv4Stack=true and user-supplied arguments, even when MAVEN_ARGS is overridden, and maven repo is ALWAYS left alone
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from decisionserver/hellorules using 1.2
+       | variable          | value                                                                                  |
+       | MAVEN_ARGS        | -e -P jboss-eap-repository-insecure,-securecentral,insecurecentral -DskipTests package |
+       | MAVEN_ARGS_APPEND | -Dfoo=bar                                                                              |
+       | MAVEN_CLEAR_REPO  | true                                                                                   |
+     Then s2i build log should contain -Djava.net.preferIPv4Stack=true
+     Then s2i build log should contain -Dfoo=bar
+     Then s2i build log should contain -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m -XX:+ExitOnOutOfMemoryError
+     Then run sh -c 'test -d /home/jboss/.m2/repository/org && echo all good' in container and check its output for all good
+
+  # CLOUD-579
+  Scenario: Test that maven is executed in batch mode
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from decisionserver/hellorules using 1.2
+    Then s2i build log should contain --batch-mode
+    And s2i build log should not contain \r
+
+  # CLOUD-1145 - base test
+  Scenario: Check custom war file was successfully deployed via CUSTOM_INSTALL_DIRECTORIES
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from custom-install-directories
+      | variable   | value                    |
+      | CUSTOM_INSTALL_DIRECTORIES | custom   |
+    Then file /opt/eap/standalone/deployments/node-info.war should exist
+
+  # CLOUD-1145 - CSV test
+  Scenario: Check all modules are successfully deployed using comma-separated CUSTOM_INSTALL_DIRECTORIES value
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from custom-install-directories
+      | variable   | value                    |
+      | CUSTOM_INSTALL_DIRECTORIES | foo,bar  |
+    Then file /opt/eap/standalone/deployments/foo.jar should exist
+    Then file /opt/eap/standalone/deployments/bar.jar should exist
+
+  Scenario: Given a project with dependencies make sure we can work offline
+    Given s2i build https://github.com/jboss-openshift/openshift-quickstarts from decisionserver/helloworld
+      | variable                   | value                                                      |
+      | KIE_CONTAINER_DEPLOYMENT   | hello-world=com.redhat.xpaas.brms:hello-world:1.0-SNAPSHOT |
+    Then s2i build log should not contain WARN Unable to resolve artifact:


### PR DESCRIPTION
[KIECLOUD-279] Move 6.4 kieserver modules into 6.4 repositories
https://issues.jboss.org/browse/KIECLOUD-279

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[KIECLOUD-XYZ] Subject` or `[RHDM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
